### PR TITLE
Redundant zeroing after a memset to zero.

### DIFF
--- a/src/portaudio_stubs.c
+++ b/src/portaudio_stubs.c
@@ -298,9 +298,7 @@ CAMLprim value ocaml_pa_open_stream(value inparam, value outparam,
   PaStreamCallback *callb = NULL;
 
   st = malloc(sizeof(stream_t));
-  memset(st, 0, sizeof(*st));
-  st->tstart = 0;
-  st->tend = 0;
+  memset(st, 0, sizeof(stream_t));
 
   if (Is_block(inparam)) {
     ip = sp_val(Field(inparam, 0), Int_val(interleaved));


### PR DESCRIPTION
It seemed like setting the structure members to zero individually after a memset to zero was redundant?
Also, I thought that `sizeof(stream_t)` was more clear than `sizeof(*st)`.