### PR TITLE
Expose Pa_GetStream{Read,Write}Available

### DIFF
--- a/src/portaudio.ml
+++ b/src/portaudio.ml
@@ -177,3 +177,9 @@ external read_stream_ba :
   int ->
   int ->
   unit = "ocaml_pa_read_stream_ba"
+
+external read_stream_available_frames : ('a, 'b, 'c, 'd) stream -> int
+  = "ocaml_pa_read_stream_available_frames"
+
+external write_stream_available_frames : ('a, 'b, 'c, 'd) stream -> int
+  = "ocaml_pa_write_stream_available_frames"

--- a/src/portaudio.mli
+++ b/src/portaudio.mli
@@ -228,3 +228,6 @@ val read_stream_ba :
   int ->
   int ->
   unit
+
+val read_stream_available_frames : ('a, 'b, 'c, 'd) stream -> int
+val write_stream_available_frames : ('a, 'b, 'c, 'd) stream -> int

--- a/src/portaudio_stubs.c
+++ b/src/portaudio_stubs.c
@@ -682,3 +682,23 @@ CAMLprim value ocaml_pa_read_stream_ba(value _stream, value _buf, value _ofs,
 
   CAMLreturn(Val_unit);
 }
+
+CAMLprim value ocaml_pa_read_stream_available_frames(value _stream) {
+  CAMLparam1(_stream);
+  PaStream *stream = Stream_val(_stream);
+  int frames_available;
+
+  frames_available = Pa_GetStreamReadAvailable(stream);
+
+  CAMLreturn(Val_int(frames_available));
+}
+
+CAMLprim value ocaml_pa_write_stream_available_frames(value _stream) {
+  CAMLparam1(_stream);
+  PaStream *stream = Stream_val(_stream);
+  int frames_available;
+
+  frames_available = Pa_GetStreamWriteAvailable(stream);
+
+  CAMLreturn(Val_int(frames_available));
+}

--- a/src/portaudio_stubs.c
+++ b/src/portaudio_stubs.c
@@ -685,20 +685,12 @@ CAMLprim value ocaml_pa_read_stream_ba(value _stream, value _buf, value _ofs,
 
 CAMLprim value ocaml_pa_read_stream_available_frames(value _stream) {
   CAMLparam1(_stream);
-  PaStream *stream = Stream_val(_stream);
-  int frames_available;
-
-  frames_available = Pa_GetStreamReadAvailable(stream);
-
+  int frames_available = Pa_GetStreamReadAvailable(Stream_val(_stream));
   CAMLreturn(Val_int(frames_available));
 }
 
 CAMLprim value ocaml_pa_write_stream_available_frames(value _stream) {
   CAMLparam1(_stream);
-  PaStream *stream = Stream_val(_stream);
-  int frames_available;
-
-  frames_available = Pa_GetStreamWriteAvailable(stream);
-
+  int frames_available = Pa_GetStreamWriteAvailable(Stream_val(_stream));
   CAMLreturn(Val_int(frames_available));
 }


### PR DESCRIPTION
Keeps the runtime lock held since I expect releasing them would worsen both throughput and latency.
